### PR TITLE
adding cppfs as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It is based on OpenGL and uses glbinding and globjects for its implementation.
 Full ist of dependencies:
 * [glm](https://github.com/g-truc/glm) (0.9.8 or higher)
 * [glfw](https://github.com/glfw/glfw) (3.2 or higher)
+* [cppfs](https://github.com/cginternals/cppfs) (1.0 or higher)
 * [cppassist](https://github.com/cginternals/cppassist) (1.0 or higher)
 * [cpplocate](https://github.com/cginternals/cpplocate) (1.0 or higher)
 * [glbinding](https://github.com/cginternals/glbinding) (3.0 or higher)


### PR DESCRIPTION
Currently cppfs is not listed as a requirement. I tested with the v1.0 tag and openll-cpp built without problems. 